### PR TITLE
Add Team Consensus Mode - 4 genius personas discuss and synthesize

### DIFF
--- a/.omc/state/subagent-tracking.json
+++ b/.omc/state/subagent-tracking.json
@@ -1,7 +1,26 @@
 {
-  "agents": [],
-  "total_spawned": 0,
-  "total_completed": 0,
+  "agents": [
+    {
+      "agent_id": "aedbeee",
+      "agent_type": "claude-code-savant:stevejobs",
+      "started_at": "2026-02-02T09:48:15.917Z",
+      "parent_mode": "none",
+      "status": "completed",
+      "completed_at": "2026-02-02T09:49:07.177Z",
+      "duration_ms": 51260
+    },
+    {
+      "agent_id": "a198adb",
+      "agent_type": "Explore",
+      "started_at": "2026-02-02T09:51:08.858Z",
+      "parent_mode": "none",
+      "status": "completed",
+      "completed_at": "2026-02-02T09:53:17.605Z",
+      "duration_ms": 128747
+    }
+  ],
+  "total_spawned": 2,
+  "total_completed": 2,
   "total_failed": 0,
-  "last_updated": "2026-02-02T09:45:40.808Z"
+  "last_updated": "2026-02-02T09:59:34.564Z"
 }

--- a/commands/savant-consensus.md
+++ b/commands/savant-consensus.md
@@ -1,0 +1,50 @@
+---
+description: Team consensus mode - all 4 genius personas discuss and synthesize insights
+---
+
+# Savant Consensus - Team Discussion Mode
+
+$ARGUMENTS
+
+## Your Task
+
+Gather opinions from all 4 genius personas (Shakespeare, Einstein, Socrates, Steve Jobs) and synthesize their insights into a unified consensus.
+
+## Execution
+
+Use the MCP tool `savant_consensus`:
+
+```
+mcp__claude-code-savant__savant_consensus:
+- question: [User's question or decision to analyze]
+- code: [Code to analyze, if provided]
+```
+
+If no code is provided, ask the user to provide the code they want analyzed.
+
+## What This Does
+
+1. **Shakespeare (The Bard)** - Analyzes code structure and flow narratively
+2. **Einstein (The Professor)** - Provides first-principles analysis with complexity metrics
+3. **Socrates (The Questioner)** - Examines edge cases and potential issues
+4. **Steve Jobs (The Visionary)** - Offers simplification and direction insights
+
+Then synthesizes all perspectives into:
+- Points of agreement
+- Key insights from each perspective
+- Recommended actions
+- Notes on differing views (if any)
+
+## When to Use
+
+- Important architectural decisions
+- Code review discussions
+- "Should we refactor this?"
+- "Is this design correct?"
+- Any decision where multiple perspectives help
+
+## Example
+
+User: "Should we refactor this authentication module?"
+
+The consensus tool will gather all 4 perspectives and provide a unified recommendation.

--- a/src/consensus/formatter.ts
+++ b/src/consensus/formatter.ts
@@ -1,0 +1,103 @@
+import { ConsensusResult, PersonaOpinion } from "./types.js";
+import { TermEntry } from "../personas/types.js";
+
+/**
+ * Format a single persona's opinion
+ */
+function formatOpinion(opinion: PersonaOpinion): string {
+  const lines: string[] = [];
+
+  lines.push(`### ${opinion.displayName}`);
+  lines.push('');
+  lines.push(`> ${opinion.summary}`);
+  lines.push('');
+
+  if (opinion.keyInsights.length > 0) {
+    lines.push('**Key Insights:**');
+    for (const insight of opinion.keyInsights) {
+      lines.push(`- ${insight}`);
+    }
+    lines.push('');
+  }
+
+  lines.push(`**Recommendation:** ${opinion.recommendation}`);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * Format terminology as Markdown table
+ */
+function formatTerminology(terms: TermEntry[]): string {
+  if (terms.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = [
+    "## Terminology\n",
+    "| **Term** | **Definition** |",
+    "|----------|----------------|",
+  ];
+
+  for (const entry of terms) {
+    const escapedDef = entry.definition.replace(/\|/g, "\\|");
+    lines.push(`| **${entry.term}** | ${escapedDef} |`);
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Format consensus result as Markdown
+ */
+export function formatConsensusOutput(result: ConsensusResult): string {
+  const sections: string[] = [];
+
+  // Header
+  sections.push('# 🎭 Team Consensus Analysis\n');
+  sections.push(`**Question:** ${result.question}\n`);
+  sections.push('---\n');
+
+  // Individual Opinions
+  sections.push('## Individual Perspectives\n');
+  for (const opinion of result.opinions) {
+    sections.push(formatOpinion(opinion));
+  }
+
+  // Synthesis
+  sections.push('---\n');
+  sections.push('## 🤝 Consensus Synthesis\n');
+
+  // Agreement
+  sections.push('### Points of Agreement\n');
+  sections.push(`${result.synthesis.agreement}\n`);
+
+  // Key Points
+  sections.push('### Key Points from Each Perspective\n');
+  for (const point of result.synthesis.keyPoints) {
+    sections.push(`- ${point}`);
+  }
+  sections.push('');
+
+  // Action Items
+  sections.push('### Recommended Actions\n');
+  for (const action of result.synthesis.actionItems) {
+    sections.push(`- ${action}`);
+  }
+  sections.push('');
+
+  // Dissent (if any)
+  if (result.synthesis.dissent) {
+    sections.push('### Note on Differing Views\n');
+    sections.push(`⚠️ ${result.synthesis.dissent}\n`);
+  }
+
+  // Terminology
+  if (result.terminology.length > 0) {
+    sections.push('---\n');
+    sections.push(formatTerminology(result.terminology));
+  }
+
+  return sections.join('\n');
+}

--- a/src/consensus/index.ts
+++ b/src/consensus/index.ts
@@ -1,0 +1,3 @@
+export { ConsensusResult, ConsensusSynthesis, PersonaOpinion } from "./types.js";
+export { analysisToOpinion, buildConsensusResult, synthesizeConsensus, mergeTerminology } from "./synthesizer.js";
+export { formatConsensusOutput } from "./formatter.js";

--- a/src/consensus/synthesizer.ts
+++ b/src/consensus/synthesizer.ts
@@ -1,0 +1,185 @@
+import { AnalysisResult, TermEntry } from "../personas/types.js";
+import { PersonaOpinion, ConsensusResult, ConsensusSynthesis } from "./types.js";
+
+/**
+ * Extract key insights from analysis content
+ */
+function extractKeyInsights(content: string): string[] {
+  const insights: string[] = [];
+
+  // Look for bullet points or numbered items
+  const bulletMatches = content.match(/^[\-\*•]\s+(.+)$/gm);
+  if (bulletMatches) {
+    insights.push(...bulletMatches.slice(0, 3).map(m => m.replace(/^[\-\*•]\s+/, '')));
+  }
+
+  // Look for sentences with key indicator words
+  const sentences = content.split(/[.!?]+/).filter(s => s.trim().length > 20);
+  const keyIndicators = ['important', 'critical', 'key', 'essential', 'must', 'should', 'recommend', '중요', '핵심', '필수'];
+
+  for (const sentence of sentences) {
+    if (keyIndicators.some(ind => sentence.toLowerCase().includes(ind))) {
+      if (insights.length < 3) {
+        insights.push(sentence.trim());
+      }
+    }
+  }
+
+  // If still not enough, take first few meaningful sentences
+  if (insights.length < 2) {
+    insights.push(...sentences.slice(0, 2).map(s => s.trim()));
+  }
+
+  return insights.slice(0, 3);
+}
+
+/**
+ * Extract recommendation from analysis
+ */
+function extractRecommendation(content: string, summary: string): string {
+  // Look for recommendation patterns
+  const recPatterns = [
+    /recommend(?:ation)?[:\s]+([^.!?]+[.!?])/i,
+    /suggest(?:ion)?[:\s]+([^.!?]+[.!?])/i,
+    /should\s+([^.!?]+[.!?])/i,
+    /결론[:\s]+([^.!?]+[.!?])/,
+    /추천[:\s]+([^.!?]+[.!?])/,
+  ];
+
+  for (const pattern of recPatterns) {
+    const match = content.match(pattern) || summary.match(pattern);
+    if (match) {
+      return match[1].trim();
+    }
+  }
+
+  // Default to summary if no explicit recommendation
+  return summary.split(/[.!?]/)[0].trim() + '.';
+}
+
+/**
+ * Convert raw analysis to persona opinion
+ */
+export function analysisToOpinion(
+  personaName: string,
+  displayName: string,
+  result: AnalysisResult
+): PersonaOpinion {
+  return {
+    personaName,
+    displayName,
+    summary: result.summary,
+    keyInsights: extractKeyInsights(result.mainContent),
+    recommendation: extractRecommendation(result.mainContent, result.summary),
+  };
+}
+
+/**
+ * Find common themes across opinions
+ */
+function findCommonThemes(opinions: PersonaOpinion[]): string[] {
+  const allInsights = opinions.flatMap(o => o.keyInsights.join(' ').toLowerCase());
+  const commonWords = new Map<string, number>();
+
+  // Key technical terms to look for
+  const technicalTerms = [
+    'performance', 'complexity', 'structure', 'pattern', 'error', 'async',
+    'function', 'class', 'loop', 'condition', 'refactor', 'simplify',
+    'test', 'validate', 'security', 'scale', 'maintain',
+    '성능', '복잡도', '구조', '패턴', '에러', '비동기', '함수', '클래스',
+    '리팩토링', '단순화', '테스트', '검증', '보안', '확장', '유지보수'
+  ];
+
+  const combinedText = allInsights.join(' ');
+  for (const term of technicalTerms) {
+    if (combinedText.includes(term.toLowerCase())) {
+      commonWords.set(term, (commonWords.get(term) || 0) + 1);
+    }
+  }
+
+  return Array.from(commonWords.entries())
+    .filter(([_, count]) => count >= 2)
+    .map(([term, _]) => term)
+    .slice(0, 5);
+}
+
+/**
+ * Synthesize consensus from multiple persona opinions
+ */
+export function synthesizeConsensus(
+  question: string,
+  opinions: PersonaOpinion[]
+): ConsensusSynthesis {
+  const commonThemes = findCommonThemes(opinions);
+
+  // Build agreement statement
+  const agreementParts: string[] = [];
+  if (commonThemes.length > 0) {
+    agreementParts.push(`All perspectives agree on the importance of: ${commonThemes.join(', ')}.`);
+  }
+
+  // Collect unique recommendations
+  const recommendations = opinions.map(o => o.recommendation);
+  const uniqueRecs = [...new Set(recommendations)];
+
+  // Build key points from each persona's strongest insight
+  const keyPoints = opinions.map(o =>
+    `**${o.displayName}**: ${o.keyInsights[0] || o.summary.split('.')[0]}`
+  );
+
+  // Build action items from recommendations
+  const actionItems = opinions.map(o =>
+    `[${o.displayName}] ${o.recommendation}`
+  );
+
+  // Check for dissent (if recommendations are very different)
+  let dissent: string | undefined;
+  if (uniqueRecs.length === opinions.length && opinions.length > 2) {
+    dissent = "Each perspective offers a unique approach. Consider the context to choose the most appropriate recommendation.";
+  }
+
+  return {
+    agreement: agreementParts.length > 0
+      ? agreementParts.join(' ')
+      : "The perspectives complement each other, each offering unique insights.",
+    keyPoints,
+    actionItems,
+    dissent,
+  };
+}
+
+/**
+ * Merge terminology from all analyses
+ */
+export function mergeTerminology(allTerms: TermEntry[][]): TermEntry[] {
+  const termMap = new Map<string, string>();
+
+  for (const terms of allTerms) {
+    for (const entry of terms) {
+      if (!termMap.has(entry.term)) {
+        termMap.set(entry.term, entry.definition);
+      }
+    }
+  }
+
+  return Array.from(termMap.entries()).map(([term, definition]) => ({
+    term,
+    definition,
+  }));
+}
+
+/**
+ * Build complete consensus result
+ */
+export function buildConsensusResult(
+  question: string,
+  opinions: PersonaOpinion[],
+  allTerminology: TermEntry[][]
+): ConsensusResult {
+  return {
+    question,
+    opinions,
+    synthesis: synthesizeConsensus(question, opinions),
+    terminology: mergeTerminology(allTerminology),
+  };
+}

--- a/src/consensus/types.ts
+++ b/src/consensus/types.ts
@@ -1,0 +1,32 @@
+import { TermEntry } from "../personas/types.js";
+
+/**
+ * Individual persona's analysis in a consensus discussion
+ */
+export interface PersonaOpinion {
+  personaName: string;
+  displayName: string;
+  summary: string;
+  keyInsights: string[];
+  recommendation: string;
+}
+
+/**
+ * Synthesized consensus from all personas
+ */
+export interface ConsensusResult {
+  question: string;
+  opinions: PersonaOpinion[];
+  synthesis: ConsensusSynthesis;
+  terminology: TermEntry[];
+}
+
+/**
+ * The final synthesized consensus
+ */
+export interface ConsensusSynthesis {
+  agreement: string;
+  keyPoints: string[];
+  actionItems: string[];
+  dissent?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerClaudeDocsExpertTool } from "./tools/claudeDocsExpert.js";
+import { registerConsensusTool } from "./tools/consensusTool.js";
 
 const SERVER_NAME = "claude-code-savant";
 const SERVER_VERSION = "1.0.0";
@@ -22,6 +23,9 @@ async function main(): Promise<void> {
   // Register tools
   registerClaudeDocsExpertTool(server);
   console.error(`[${SERVER_NAME}] Registered tool: claude_docs_expert`);
+
+  registerConsensusTool(server);
+  console.error(`[${SERVER_NAME}] Registered tool: savant_consensus`);
 
   // Connect via STDIO transport
   const transport = new StdioServerTransport();

--- a/src/tools/consensusTool.ts
+++ b/src/tools/consensusTool.ts
@@ -1,0 +1,89 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getPersona, getAvailablePersonas, PersonaType } from "../personas/index.js";
+import { analysisToOpinion, buildConsensusResult, formatConsensusOutput } from "../consensus/index.js";
+import { TermEntry } from "../personas/types.js";
+
+/**
+ * Input schema for the consensus tool
+ */
+const inputSchema = z.object({
+  question: z
+    .string()
+    .min(1)
+    .describe("The question or decision to analyze (e.g., 'Is this architecture correct?', 'Should we refactor this?')"),
+  code: z
+    .string()
+    .min(1)
+    .describe("The code to analyze and discuss"),
+});
+
+/**
+ * Register the consensus tool with the MCP server
+ */
+export function registerConsensusTool(server: McpServer): void {
+  server.tool(
+    "savant_consensus",
+    "Initiates a team discussion where all 4 genius personas (Shakespeare, Einstein, Socrates, Steve Jobs) analyze the code simultaneously and synthesize their insights into a unified consensus. Perfect for important architectural decisions, code reviews, and when you need multiple perspectives.",
+    inputSchema.shape,
+    async (args) => {
+      try {
+        const { question, code } = args as z.infer<typeof inputSchema>;
+
+        console.error(`[savant_consensus] Starting team consensus for: "${question.slice(0, 50)}..."`);
+
+        // Get all personas
+        const personaTypes = getAvailablePersonas();
+        console.error(`[savant_consensus] Gathering opinions from ${personaTypes.length} personas...`);
+
+        // Collect opinions from all personas
+        const opinions = [];
+        const allTerminology: TermEntry[][] = [];
+
+        for (const personaType of personaTypes) {
+          const persona = getPersona(personaType);
+          console.error(`[savant_consensus] Analyzing with ${persona.displayName}...`);
+
+          const result = persona.analyze(question, code);
+          const opinion = analysisToOpinion(personaType, persona.displayName, result);
+
+          opinions.push(opinion);
+          allTerminology.push(result.terminology);
+        }
+
+        console.error(`[savant_consensus] Synthesizing consensus...`);
+
+        // Build consensus result
+        const consensusResult = buildConsensusResult(question, opinions, allTerminology);
+
+        // Format output
+        const output = formatConsensusOutput(consensusResult);
+
+        console.error(`[savant_consensus] Team consensus complete`);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: output,
+            },
+          ],
+        };
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        console.error(`[savant_consensus] Error: ${errorMessage}`);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error during consensus analysis: ${errorMessage}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/tests/consensus.test.ts
+++ b/tests/consensus.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from "vitest";
+import {
+  analysisToOpinion,
+  buildConsensusResult,
+  synthesizeConsensus,
+  mergeTerminology,
+} from "../src/consensus/synthesizer.js";
+import { formatConsensusOutput } from "../src/consensus/formatter.js";
+import { AnalysisResult, TermEntry } from "../src/personas/types.js";
+import { PersonaOpinion } from "../src/consensus/types.js";
+
+describe("Consensus Synthesizer", () => {
+  const mockAnalysisResult: AnalysisResult = {
+    summary: "This code demonstrates important patterns for data processing.",
+    mainContent: `
+      The code shows a clear structure.
+      - It handles errors properly
+      - Performance is critical here
+      - Should consider edge cases
+    `,
+    terminology: [
+      { term: "Loop", definition: "A repeating construct" },
+    ],
+  };
+
+  describe("analysisToOpinion", () => {
+    it("should convert analysis result to persona opinion", () => {
+      const opinion = analysisToOpinion("shakespeare", "The Bard", mockAnalysisResult);
+
+      expect(opinion.personaName).toBe("shakespeare");
+      expect(opinion.displayName).toBe("The Bard");
+      expect(opinion.summary).toBe(mockAnalysisResult.summary);
+      expect(opinion.keyInsights.length).toBeGreaterThan(0);
+      expect(opinion.recommendation).toBeDefined();
+    });
+
+    it("should extract key insights from bullet points", () => {
+      const opinion = analysisToOpinion("einstein", "The Professor", mockAnalysisResult);
+
+      // Should have extracted insights
+      expect(opinion.keyInsights.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe("synthesizeConsensus", () => {
+    const mockOpinions: PersonaOpinion[] = [
+      {
+        personaName: "shakespeare",
+        displayName: "The Bard",
+        summary: "A dramatic tale of data flow.",
+        keyInsights: ["Structure is key", "Performance matters"],
+        recommendation: "Refactor for clarity.",
+      },
+      {
+        personaName: "einstein",
+        displayName: "The Professor",
+        summary: "First principles analysis shows O(n) complexity.",
+        keyInsights: ["Complexity is manageable", "Performance is good"],
+        recommendation: "Optimize the inner loop.",
+      },
+      {
+        personaName: "socrates",
+        displayName: "The Questioner",
+        summary: "What happens when input is empty?",
+        keyInsights: ["Edge cases need handling", "Error handling is important"],
+        recommendation: "Add validation.",
+      },
+      {
+        personaName: "stevejobs",
+        displayName: "The Visionary",
+        summary: "Simplify. Remove half the code.",
+        keyInsights: ["Too complex", "Focus on core"],
+        recommendation: "Kill features, ship faster.",
+      },
+    ];
+
+    it("should synthesize consensus from multiple opinions", () => {
+      const synthesis = synthesizeConsensus("Should we refactor?", mockOpinions);
+
+      expect(synthesis.agreement).toBeDefined();
+      expect(synthesis.keyPoints.length).toBe(4);
+      expect(synthesis.actionItems.length).toBe(4);
+    });
+
+    it("should include key points from each persona", () => {
+      const synthesis = synthesizeConsensus("Is this good?", mockOpinions);
+
+      expect(synthesis.keyPoints[0]).toContain("The Bard");
+      expect(synthesis.keyPoints[1]).toContain("The Professor");
+      expect(synthesis.keyPoints[2]).toContain("The Questioner");
+      expect(synthesis.keyPoints[3]).toContain("The Visionary");
+    });
+
+    it("should note dissent when recommendations differ", () => {
+      const synthesis = synthesizeConsensus("What to do?", mockOpinions);
+
+      // All 4 have different recommendations
+      expect(synthesis.dissent).toBeDefined();
+    });
+  });
+
+  describe("mergeTerminology", () => {
+    it("should merge terminology from multiple sources", () => {
+      const terms1: TermEntry[] = [
+        { term: "Loop", definition: "A repeating construct" },
+      ];
+      const terms2: TermEntry[] = [
+        { term: "Function", definition: "A callable block" },
+        { term: "Loop", definition: "Different definition" }, // duplicate
+      ];
+
+      const merged = mergeTerminology([terms1, terms2]);
+
+      expect(merged.length).toBe(2);
+      // First definition should win
+      const loopTerm = merged.find(t => t.term === "Loop");
+      expect(loopTerm?.definition).toBe("A repeating construct");
+    });
+
+    it("should handle empty arrays", () => {
+      const merged = mergeTerminology([[], []]);
+      expect(merged.length).toBe(0);
+    });
+  });
+
+  describe("buildConsensusResult", () => {
+    const mockOpinions: PersonaOpinion[] = [
+      {
+        personaName: "shakespeare",
+        displayName: "The Bard",
+        summary: "A tale of code.",
+        keyInsights: ["Insight 1"],
+        recommendation: "Rec 1.",
+      },
+      {
+        personaName: "einstein",
+        displayName: "The Professor",
+        summary: "Analysis complete.",
+        keyInsights: ["Insight 2"],
+        recommendation: "Rec 2.",
+      },
+    ];
+
+    it("should build complete consensus result", () => {
+      const terms: TermEntry[][] = [
+        [{ term: "Test", definition: "Testing" }],
+        [],
+      ];
+
+      const result = buildConsensusResult("Question?", mockOpinions, terms);
+
+      expect(result.question).toBe("Question?");
+      expect(result.opinions.length).toBe(2);
+      expect(result.synthesis).toBeDefined();
+      expect(result.terminology.length).toBe(1);
+    });
+  });
+});
+
+describe("Consensus Formatter", () => {
+  it("should format consensus result as markdown", () => {
+    const mockResult = {
+      question: "Should we refactor this code?",
+      opinions: [
+        {
+          personaName: "shakespeare",
+          displayName: "The Bard",
+          summary: "A dramatic journey.",
+          keyInsights: ["Key insight 1"],
+          recommendation: "Refactor with care.",
+        },
+        {
+          personaName: "einstein",
+          displayName: "The Professor",
+          summary: "Logically sound.",
+          keyInsights: ["Key insight 2"],
+          recommendation: "Optimize complexity.",
+        },
+      ],
+      synthesis: {
+        agreement: "All agree on importance of structure.",
+        keyPoints: [
+          "**The Bard**: Key insight 1",
+          "**The Professor**: Key insight 2",
+        ],
+        actionItems: [
+          "[The Bard] Refactor with care.",
+          "[The Professor] Optimize complexity.",
+        ],
+      },
+      terminology: [
+        { term: "Refactor", definition: "Restructure code" },
+      ],
+    };
+
+    const output = formatConsensusOutput(mockResult);
+
+    expect(output).toContain("# 🎭 Team Consensus Analysis");
+    expect(output).toContain("**Question:** Should we refactor this code?");
+    expect(output).toContain("## Individual Perspectives");
+    expect(output).toContain("### The Bard");
+    expect(output).toContain("### The Professor");
+    expect(output).toContain("## 🤝 Consensus Synthesis");
+    expect(output).toContain("### Points of Agreement");
+    expect(output).toContain("### Key Points from Each Perspective");
+    expect(output).toContain("### Recommended Actions");
+    expect(output).toContain("## Terminology");
+  });
+
+  it("should include dissent section when present", () => {
+    const mockResult = {
+      question: "Test?",
+      opinions: [],
+      synthesis: {
+        agreement: "Some agreement.",
+        keyPoints: [],
+        actionItems: [],
+        dissent: "Views differ significantly.",
+      },
+      terminology: [],
+    };
+
+    const output = formatConsensusOutput(mockResult);
+
+    expect(output).toContain("### Note on Differing Views");
+    expect(output).toContain("Views differ significantly.");
+  });
+});


### PR DESCRIPTION
## Summary

- **New Feature**: Team Consensus Mode where all 4 genius personas (Shakespeare, Einstein, Socrates, Steve Jobs) analyze code simultaneously
- **MCP Tool**: `savant_consensus` for team discussions
- **AI Synthesis**: Combines all perspectives into unified consensus with agreement points, key insights, action items, and dissent notes
- **CLI Command**: `/savant-consensus` for easy access

## What it does

1. User asks a question about code (e.g., "Should we refactor this?")
2. All 4 personas analyze the code from their unique perspectives:
   - **Shakespeare**: Narrative flow and structure
   - **Einstein**: First principles and complexity
   - **Socrates**: Edge cases and root causes  
   - **Steve Jobs**: Simplification and vision
3. AI synthesizes all opinions into:
   - Points of agreement
   - Key insights from each perspective
   - Recommended actions
   - Notes on differing views (if any)

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 29 tests pass (`npm test`)
- [x] New consensus tests added (10 tests)
- [ ] Manual test with `/savant-consensus` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)